### PR TITLE
Match scatter output to matplotlib api changes

### DIFF
--- a/src/egttools/plotting/indicators.py
+++ b/src/egttools/plotting/indicators.py
@@ -134,9 +134,9 @@ def plot_gradients(gradients: numpy.ndarray, fig_title: Optional[str] = None,
 
     ax.plot(x_values, gradients, color=color, linewidth=linewidth_gradient, label=linelabel, zorder=1)
     if marker is not None:
-        ax.scatter(x_values[::marker_plot_freq], gradients[::marker_plot_freq], marker=marker, s=marker_size, facecolors=marker_facecolor,
-                   edgecolors=marker_edgecolor, linewidths=marker_linewidth, zorder=1.5)
-
+        [ ax.scatter(x_values[::marker_plot_freq], gradient[::marker_plot_freq], 
+marker=marker, s=marker_size, facecolors=marker_facecolor,
+			   edgecolors=marker_edgecolor, linewidths=marker_linewidth, zorder=1.5) for gradient in gradients.T]
     # if stability is given, draw the stable points and arrows
     if stability is not None:
         if roots is None:
@@ -476,3 +476,4 @@ def draw_invasion_diagram(strategies: List[str], drift: float, fixation_probabil
                     horizontalalignment='center', fontsize=font_size_sd_labels)
 
     return G
+

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,52 @@
+import pytest
+import numpy as np, networkx as nx, egttools as egt, matplotlib.pyplot as plt
+
+
+def test_plot_gradients_2d_array():
+    gradients = np.random.rand(10, 2)
+    # all ok returns None
+    assert isinstance(egt.plotting.plot_gradients(gradients), plt.Axes)
+
+
+def test_plot_gradient_none_input():
+    # should error on input not being a np.array
+    # accessing a particular atribute
+    with pytest.raises(AttributeError):
+        egt.plotting.plot_gradients(None)
+
+
+def test_draw_invasion_diagram():
+    # preliminary from the examples
+    T, R, P, S, beta, Z = 2, 1, 0, 1, 1, 100
+    A = np.array([[P, T], [S, R]])
+
+    strategies = [
+        egt.behaviors.NormalForm.TwoActions.Cooperator(),
+        egt.behaviors.NormalForm.TwoActions.Random(),
+        egt.behaviors.NormalForm.TwoActions.GRIM(),
+    ]
+
+    strategy_labels = [
+        strategy.type().replace("NFGStrategies::", "") for strategy in strategies
+    ]
+
+    game = egt.games.NormalFormGame(1, A, strategies)
+    evolver = egt.analytical.PairwiseComparison(Z, game)
+    (
+        transition_matrix,
+        fixation_probabilities,
+    ) = evolver.calculate_transition_and_fixation_matrix_sml(beta)
+
+    stationary_distribution = egt.utils.calculate_stationary_distribution(
+        transition_matrix.transpose()
+    )
+
+    assert isinstance(
+        egt.plotting.draw_invasion_diagram(
+            strategies=strategy_labels,
+            drift=1,
+            fixation_probabilities=fixation_probabilities,
+            stationary_distribution=stationary_distribution,
+        ),
+        nx.DiGraph,
+    )


### PR DESCRIPTION
Apparently matplotlib changed something in the api to prevent broadcasting scatter arrays  (plot still works). 
This corrects it. I believe there are no other places in the codebase that interferes with it.

<details> <summary> Example </summary>

```python
import numpy as np
from egttools.analytical import PairwiseComparison
from egttools.games import Matrix2PlayerGameHolder
import matplotlib.pyplot as plt

beta = 1
Z = 100
nb_strategies = 2
A = np.array([[-0.5, 2.0], [0.0, 0.0]])
pop_states = np.arange(0, Z + 1, 1)

game = Matrix2PlayerGameHolder(nb_strategies, payoff_matrix=A)

# Instantiate evolver and calculate gradient
evolver = PairwiseComparison(population_size=Z, game=game)
gradients = np.array(
    [
        evolver.calculate_gradient_of_selection(beta, np.array([x, Z - x]))
        for x in range(Z + 1)
    ]
)

from egttools.plotting import plot_gradients

plot_gradients(
    gradients,
    figsize=(4, 4),
    fig_title="Hawk-Dove game stochastic dynamics",
    marker_facecolor="white",
    xlabel="frequency of hawks (k/Z)",
    marker="o",
    marker_size=20,
    marker_plot_freq=2,
)
plt.show(block = 1)

```
</details>

Using mpl 3.5.3